### PR TITLE
chore: refining requests module for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 For a quick start with sttp and zio json, add the following to your library dependencies in `build.sbt`:
 
 ```sbt
-  "com.lumidion"  %%  "sonatype-central-client-sttp-core"  %  "0.1.0"
-  "com.lumidion"  %%  "sonatype-central-client-zio-json"   %  "0.1.0"
+  "com.lumidion"  %%  "sonatype-central-client-sttp-core"  %  "0.2.0"
+  "com.lumidion"  %%  "sonatype-central-client-zio-json"   %  "0.2.0"
   "com.softwaremill.sttp.client4" %% "zio-json"            %  "4.0.0-M11"
 ```
 
@@ -59,7 +59,7 @@ object Main {
 For a quick start with requests, add the following to your library dependencies in `build.sbt`:
 
 ```sbt
-  "com.lumidion"  %%  "sonatype-central-client-requests"  %  "0.1.0"
+  "com.lumidion"  %%  "sonatype-central-client-requests"  %  "0.2.0"
 ```
 
 #### Simple App

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ val versions = new {
   val scalatest = "3.2.18"
   val zioJson   = "0.6.2"
   val requests  = "0.8.2"
-  val upickle   = "3.2.0"
+  val upickle   = "3.3.0"
 }
 
 val commonSettings = Seq(

--- a/modules/core/src/main/scala/com/lumidion/sonatype/central/client/core/SonatypeCentralError.scala
+++ b/modules/core/src/main/scala/com/lumidion/sonatype/central/client/core/SonatypeCentralError.scala
@@ -1,0 +1,31 @@
+package com.lumidion.sonatype.central.client.core
+
+trait SonatypeCentralError extends Exception {
+  val name: String
+}
+
+object SonatypeCentralError {
+  final case class AuthorizationError(msg: String) extends SonatypeCentralError {
+    override val name: String = "Sonatype Central Authorization Error"
+
+    override def getMessage: String = s"$name: $msg"
+  }
+
+  final case class GenericError(ex: Throwable) extends SonatypeCentralError {
+    override val name: String = "Sonatype Central Generic Error"
+
+    override def getMessage: String = s"$name: ${ex.getMessage}"
+  }
+
+  final case class GenericUserError(msg: String) extends SonatypeCentralError {
+    override val name: String = "Sonatype Central Generic User Error"
+
+    override def getMessage: String = s"$name: $msg"
+  }
+
+  final case class InternalServerError(msg: String) extends SonatypeCentralError {
+    override val name: String = "Sonatype Central Internal Server Error"
+
+    override def getMessage: String = s"$name: $msg"
+  }
+}


### PR DESCRIPTION
### Description

This PR introduces error types for the request module and updates the readme so that the versions numbers reflect the upcoming release.

It also removes the `uploadBundle` in the requests module and replaces it with two methods: `uploadBundleFromFile` and `uploadBundleFromBytes`.

Finally, it adds timeout parameters to the requests client.