### PR TITLE
chore: fixing outdated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ object Main {
     val file        = new File("mybundle.zip")
 
     val deploymentId = client
-      .uploadBundle(
+      .uploadBundleFromFile(
         file,
         DeploymentName("com.testing.project-1.0.0"),
         Some(PublishingType.AUTOMATIC)


### PR DESCRIPTION
Readme method name was incorrect for the sample requests app.