### PR TITLE
feat: adding upickle module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.url
 import scala.collection.Seq
 
-addCommandAlias("format", "scalafmtAll; scalafmtSbt")
+addCommandAlias("fmt", "scalafmtAll; scalafmtSbt")
 
 val globals = new {
   val projectName      = "sonatype-central-client"
@@ -32,8 +32,8 @@ val versions = new {
   val scala213  = "2.13.13"
   val scala3    = "3.3.3"
   val sttp      = "4.0.0-M16"
-  val scalatest = "3.2.18"
-  val zioJson   = "0.7.0"
+  val scalatest = "3.2.19"
+  val zioJson   = "0.7.1"
   val requests  = "0.8.2"
   val upickle   = "3.3.1"
 }
@@ -48,7 +48,8 @@ val commonSettings = Seq(
         "-deprecation"
       )
     } else Seq.empty
-  }
+  },
+  publishTo := sonatypeCentralPublishToBundle.value
 )
 
 lazy val core = (project in file("modules/core"))
@@ -61,18 +62,27 @@ lazy val requests = (project in file("modules/requests"))
   .settings(
     name := s"${globals.projectName}-requests",
     libraryDependencies ++= Seq(
-      "com.lihaoyi" %% "requests" % versions.requests,
-      "com.lihaoyi" %% "upickle"  % versions.upickle
+      "com.lihaoyi" %% "requests" % versions.requests
     )
   )
   .settings(commonSettings)
-  .dependsOn(core)
+  .dependsOn(core, upickle)
 
 lazy val sttp_core = (project in file("modules/sttp-core"))
   .settings(
     name := s"${globals.projectName}-sttp-core",
     libraryDependencies ++= Seq(
       "com.softwaremill.sttp.client4" %% "core" % versions.sttp
+    )
+  )
+  .settings(commonSettings)
+  .dependsOn(core)
+
+lazy val upickle = (project in file("modules/upickle"))
+  .settings(
+    name := s"${globals.projectName}-upickle",
+    libraryDependencies ++= Seq(
+      "com.lihaoyi" %% "upickle" % versions.upickle
     )
   )
   .settings(commonSettings)
@@ -104,4 +114,4 @@ lazy val root = (project in file("."))
     publish / skip := true,
     name           := globals.projectName
   )
-  .aggregate(core, requests, sttp_core, zio_json)
+  .aggregate(core, requests, upickle, sttp_core, zio_json)

--- a/modules/requests/src/main/scala/com/lumidion/sonatype/central/client/requests/SyncSonatypeClient.scala
+++ b/modules/requests/src/main/scala/com/lumidion/sonatype/central/client/requests/SyncSonatypeClient.scala
@@ -4,7 +4,6 @@ import com.lumidion.sonatype.central.client.core.{
   CheckStatusResponse,
   DeploymentId,
   DeploymentName,
-  DeploymentState,
   GenericSonatypeClient,
   PublishingType,
   SonatypeCredentials
@@ -19,6 +18,7 @@ import com.lumidion.sonatype.central.client.core.SonatypeCentralError.{
   GenericUserError,
   InternalServerError
 }
+import com.lumidion.sonatype.central.client.upickle.decoders._
 
 import java.io.File
 import requests.{BaseSession, MultiItem, MultiPart, Session}
@@ -30,20 +30,6 @@ class SyncSonatypeClient(
     readTimeout: Int = 300 * 1000,
     connectTimeout: Int = 5000
 ) extends GenericSonatypeClient {
-
-  implicit protected val deploymentIdDecoder: Reader[DeploymentId] =
-    upickle.default.reader[ujson.Str].map(str => DeploymentId(str.value))
-  implicit protected val deploymentNameDecoder: Reader[DeploymentName] = {
-    upickle.default.reader[ujson.Str].map(str => DeploymentName(str.value))
-  }
-  implicit protected val deploymentStateDecoder: Reader[DeploymentState] =
-    upickle.default.reader[ujson.Str].map { str =>
-      DeploymentState
-        .decoder(str.value)
-        .fold(errorMessage => throw new Exception(errorMessage), identity)
-    }
-  implicit protected val checkStatusResponseBodyDecoder: Reader[CheckStatusResponse] =
-    macroR[CheckStatusResponse]
 
   private val authHeader = Map("Authorization" -> credentials.toAuthToken)
 

--- a/modules/sttp-core/src/main/scala/com/lumidion/sonatype/central/client/sttp/core/BaseSonatypeClient.scala
+++ b/modules/sttp-core/src/main/scala/com/lumidion/sonatype/central/client/sttp/core/BaseSonatypeClient.scala
@@ -29,8 +29,14 @@ abstract class BaseSonatypeClient(
     credentials: SonatypeCredentials,
     loggingOptions: Option[LoggingOptions] = None
 ) extends GenericSonatypeClient {
+  private val finalLoggingOptions = loggingOptions.getOrElse(LoggingOptions(None, None, None, None))
   private val baseRequest = quickRequest
-    .logSettings(loggingOptions)
+    .logSettings(
+      logRequestBody = finalLoggingOptions.logRequestBody,
+      logResponseBody = finalLoggingOptions.logResponseBody,
+      logRequestHeaders = finalLoggingOptions.logRequestHeaders,
+      logResponseHeaders = finalLoggingOptions.logResponseHeaders
+    )
     .headers(Map(HeaderNames.Authorization -> credentials.toAuthToken))
 
   def uploadBundleRequest(

--- a/modules/upickle/src/main/scala/com/lumidion/sonatype/central/client/upickle/decoders/package.scala
+++ b/modules/upickle/src/main/scala/com/lumidion/sonatype/central/client/upickle/decoders/package.scala
@@ -1,0 +1,26 @@
+package com.lumidion.sonatype.central.client.upickle
+
+import com.lumidion.sonatype.central.client.core.{
+  CheckStatusResponse,
+  DeploymentId,
+  DeploymentName,
+  DeploymentState
+}
+
+import upickle.default._
+
+package object decoders {
+  implicit val deploymentIdDecoder: Reader[DeploymentId] =
+    upickle.default.reader[ujson.Str].map(str => DeploymentId(str.value))
+  implicit val deploymentNameDecoder: Reader[DeploymentName] = {
+    upickle.default.reader[ujson.Str].map(str => DeploymentName(str.value))
+  }
+  implicit val deploymentStateDecoder: Reader[DeploymentState] =
+    upickle.default.reader[ujson.Str].map { str =>
+      DeploymentState
+        .decoder(str.value)
+        .fold(errorMessage => throw new Exception(errorMessage), identity)
+    }
+  implicit val checkStatusResponseBodyDecoder: Reader[CheckStatusResponse] =
+    macroR[CheckStatusResponse]
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
-addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.1")
-addSbtPlugin("org.scalameta"       % "sbt-scalafmt"     % "2.5.2")
-addSbtPlugin("com.github.sbt"      % "sbt-ci-release"   % "1.5.12")
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings"     % "1.1.1")
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"         % "2.5.2")
+addSbtPlugin("com.github.sbt"      % "sbt-ci-release"       % "1.5.12")
+addSbtPlugin("com.lumidion"        % "sbt-sonatype-central" % "0.1.0")


### PR DESCRIPTION
This PR adds a new module for upickle decoders that can be consumed via the following dependency in `build.sbt`: 
`"com.lumidion" %% "sonatype-central-client-upickle" % "<version_number>"`.