### PR TITLE
chore: Use gigahorse-apache-http

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -147,7 +147,7 @@ lazy val gigahorse = (project in file("modules/gigahorse"))
   .settings(
     name := s"${globals.projectName}-gigahorse",
     libraryDependencies ++= Seq(
-      "com.eed3si9n" %% "gigahorse-okhttp" % versions.gigahorse
+      "com.eed3si9n" %% "gigahorse-apache-http" % versions.gigahorse
     ),
     Compile / scalacOptions += "-release:8",
   )

--- a/modules/gigahorse/src/main/scala/com/lumidion/sonatype/central/client/gigahorse/SyncSonatypeClient.scala
+++ b/modules/gigahorse/src/main/scala/com/lumidion/sonatype/central/client/gigahorse/SyncSonatypeClient.scala
@@ -30,7 +30,7 @@ import gigahorse.{
   MultipartFormBody,
   Request
 }
-import gigahorse.support.okhttp.Gigahorse
+import gigahorse.support.apachehttp.Gigahorse
 import java.io.File
 import scala.annotation.tailrec
 import scala.concurrent.{Await, ExecutionContext, Future}

--- a/modules/integration-test/src/test/scala/com/lumidion/sonatype/central/client/integration/test/GigahorseItSpec.scala
+++ b/modules/integration-test/src/test/scala/com/lumidion/sonatype/central/client/integration/test/GigahorseItSpec.scala
@@ -13,7 +13,7 @@ import com.lumidion.sonatype.central.client.integration.test.Utils.{
   zippedBundle
 }
 
-import gigahorse.support.okhttp.Gigahorse
+import gigahorse.support.apachehttp.Gigahorse
 import java.util.UUID
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,6 @@
 object Dependencies {
   val versions = new {
-    val gigahorse = "0.9.0"
+    val gigahorse = "0.9.1"
     val requests  = "0.9.0"
     val scala212  = "2.12.20"
     val scala213  = "2.13.16"


### PR DESCRIPTION
This switches the backend of Gigahorse to Apache HttpClient 5.x, instead of OkHttp 3.x.